### PR TITLE
Add option for open source with support

### DIFF
--- a/questionnaire/2019/questions.yaml
+++ b/questionnaire/2019/questions.yaml
@@ -250,7 +250,8 @@
     responses:
     - buy 
     - build internally
-    - use open source / no support
+    - use open source without support
+    - use open source with support
     - no prefered approach, varies on case by case
 
 # ----------------------------------------------------


### PR DESCRIPTION
Someone suggested to add "use open source with support" as an option for the question about buy/build/oss 
the idea is to differentiate `Buy: closed source product` and vs `Buy support for an OSS project`

 I think it make sense 