### PR TITLE
Add unique ID per question

### DIFF
--- a/questionnaire/2016/questions.yaml
+++ b/questionnaire/2016/questions.yaml
@@ -2,9 +2,11 @@
 
 ---
 - section: OPERATION/MANAGEMENT OF YOUR NETWORK
+  
   questions:
   - title: What operations in your network are currently automated? 
     type: Multiple choice 
+    id: operation-automated
     responses:
     - Day 0 Provisioning using a vendor solution (ZTP, POAP, Amnesiac, etc.)
     - Configuration generation
@@ -19,7 +21,8 @@
     - Compliance Checks
     - Other…
 
-  - title: How are you keeping track of your configuration changes? 
+  - title: How are you keeping track of your configuration changes?
+    id: config-track-changes
     type: Multiple choice 
     responses:
     - Version control (github, gitlab, svn …)
@@ -30,6 +33,7 @@
     - Other…
   
   - title: Have you automated the decision to deploy a new configuration? (auto-remediation, auto-change-validation)
+    id: config-decide-changes
     type: Single choice 
     responses:
     - Yes
@@ -37,12 +41,14 @@
     - No
 
   - title: Do you allow configurations to be manually changed via CLI in addition to automated deployments?
+    id: config-automated-changes
     type: Single choice 
     responses:
     - Yes
     - No
 
   - title: Configuration – If you are automating the generation and/or the deployment of your configurations what solution(s) are you using?
+    id: config-gen-deploy
     type: Multiple choice 
     responses:
     - Ansible
@@ -59,10 +65,11 @@
     - Other…
 
   - title: How often do you make changes in production
-    type: Multiple choice 
+    id: prod-changes
+    type: Multiple choice grid
     responses:
-    - Minor changes
-    - Major changes
+    - { text: Minor changes, id: minor }
+    - { text: Major changes, id: major }
     options:
     - Not sure
     - Less than 1 per month
@@ -71,6 +78,7 @@
     - More than 1 a day
 
   - title: Troubleshooting - If you are automating the troubleshooting of your network what solution(s) are you using?
+    id: troubleshoot
     type: Multiple choice 
     responses:
     - Ansible
@@ -87,6 +95,7 @@
     - Other…
 
   - title: Software Upgrade - If you are automating software upgrades in your network what solution(s) are you using?
+    id: software-upgrade
     type: Multiple choice 
     responses:
     - Ansible
@@ -100,6 +109,7 @@
 
   - title: Software Qualification/Validation - If you are automating software qualification for your network what solution(s) are you using?
     type: Multiple choice 
+    id: software-validation
     responses:
     - Ansible
     - Chef
@@ -115,6 +125,7 @@
   
   - title: Anomaly detection – If you have automated the detection of anomaly in your network, what solution(s) are you using? 
     type: Multiple choice 
+    id: anomaly-detection
     responses:
     - Ansible
     - Chef
@@ -133,6 +144,7 @@
   questions:
   - title: How many network devices are you managing?
     type: Single choice 
+    id: env-nbr-devices
     responses:
     - 0-50
     - 51-250
@@ -141,6 +153,7 @@
 
   - title: Which networking vendor devices are you managing?
     type: Multiple choice 
+    id: env-vendors
     responses:
     - Arista
     - Big Switch
@@ -156,6 +169,7 @@
 
   - title: What types of environments are you managing?
     type: Multiple choice 
+    id: env-type
     responses:
     - Datacenter
     - Campus/User Access
@@ -165,21 +179,23 @@
 
   - title: What programmatic language(s) are you using? 
     type: Multiple choice grid 
+    id: env-language
     responses:
-    - Python
-    - Golang
-    - Javascript
-    - Ruby
-    - C/C++
-    - Shell
-    - Other
+    - { text: Python, id: python }
+    - { text: Golang, id: golang }
+    - { text: Javascript, id: javascript }
+    - { text: Ruby, id: ruby }
+    - { text: C/C++, id: c-cpp }
+    - { text: Shell, id: shell }
+    - { text: Other, id: other }
     options:
     - None
     - A little
     - A lot
 
   - title: Which solution are you using to run virtual network devices for training or qualification purpose?
-    type: Multiple choice 
+    type: Multiple choice
+    id: env-virtual-network
     responses:
     - Vagrant
     - VMWare
@@ -196,6 +212,7 @@
   
   - title: On the server side, what automation tools are you using ?
     type: Multiple choice 
+    id: env-server-automation
     responses:
     - Ansible
     - Chef
@@ -209,6 +226,7 @@
   
   - title: Where are you located?
     type: Single choice 
+    id: env-location
     responses:
     - North America
     - South America
@@ -223,15 +241,16 @@
 - section: INDUSTRY TRENDS/ FUTURE DIRECTIONS
   questions:
   - title: In the following list of topic, which one are you interested about or have currently implemented ?
-    type: Multiple choice grid 
+    type: Multiple choice grid
+    id: trend-topics
     responses:
-    - Infrastructure as code
-    - Event Driven Automation
-    - Chatops
-    - Continuous Integration/ Delivery - CI/CD
-    - Devops
-    - Telemetry streaming
-    - Intent based solution
+    - { text: Infrastructure as code, id: iac }
+    - { text: Event Driven Automation, id: event-driven }
+    - { text: Chatops, id: chatops }
+    - { text: Continuous Integration/ Delivery - CI/CD, id: ci-cd }
+    - { text: Devops, id: devops }
+    - { text: Telemetry streaming, id: telemetry-streaming }
+    - { text: Intent based solution, id: ibns }
     options:
     - I don't know
     - No interest
@@ -241,19 +260,20 @@
 
   - title: In the following list of tool, which one are you interested about or have currently implemented ?
     type: Multiple choice grid 
+    id: trend-tools
     responses: 
-    - Ansible
-    - Chef
-    - Puppet
-    - Saltstack
-    - NAPALM
-    - Git (github/gitlab)
-    - Keyword based testing (RobotFramework, Behave)
-    - CI (jenkins, travis-ci, circle-ci, gitlab-ci)
-    - Stackstorm
-    - Apstra AOS
-    - GluWare 
-    - Anuta Networks
+    - { text: Ansible, id: ansible }
+    - { text: Chef, id: chef }
+    - { text: Puppet, id: puppet }
+    - { text: Saltstack, id: saltstack }
+    - { text: NAPALM, id: napalm }
+    - { text: Git (github/gitlab), id: git }
+    - { text: Keyword based testing (RobotFramework, Behave), id: keyword-testing }
+    - { text: CI (jenkins, travis-ci, circle-ci, gitlab-ci), id: ci }
+    - { text: Stackstorm, id: stackstorm }
+    - { text: Apstra AOS, id: apstra }
+    - { text: GluWare, id: gluware }
+    - { text: Anuta Networks, id: anuta-networks }
     options:
     - I don't know
     - No interest
@@ -264,5 +284,6 @@
 - section: Feedback
   questions:
   - title: Open form for feedback or additional informations you would like to share. (Attention everyone will have access to it)
-    type: Open form
+    type: Open Form
+    id: feedback
 

--- a/questionnaire/2019/questions.yaml
+++ b/questionnaire/2019/questions.yaml
@@ -13,6 +13,7 @@
   questions:
   - title: What operations in your network are currently automated? 
     type: Multiple choice 
+    id: operation-automated
     responses:
     - Day 0 Provisioning using a vendor solution (ZTP, POAP, Amnesiac, etc.)
     - Configuration generation
@@ -29,7 +30,8 @@
     - Topology Mapping
 
   - title: How are you keeping track of your configuration changes? 
-    type: Multiple choice 
+    type: Multiple choice
+    id: config-track-changes
     responses:
     - Version control (github, gitlab, svn …)
     - FTP/SCP/TFTP
@@ -46,6 +48,7 @@
   
   - title: Have you automated the decision to deploy a new configuration? (auto-remediation, auto-change-validation)
     type: Single choice 
+    id: config-decide-changes
     responses:
     - Yes
     - Partially
@@ -53,12 +56,14 @@
 
   - title: Do you allow configurations to be manually changed via CLI in addition to automated deployments?
     type: Single choice 
+    id: config-automated-changes
     responses:
     - Yes
     - No
 
   - title: Configuration – If you are automating the generation and/or the deployment of your configurations what solution(s) are you using?
     type: Multiple choice 
+    id: config-gen-deploy
     responses:
     - Excel macros
     - Ansible
@@ -77,10 +82,11 @@
     - Other (text field)
 
   - title: How often do you make changes in production
-    type: Multiple choice 
+    type: Multiple choice grid
+    id: prod-changes
     responses:
-    - Minor changes
-    - Major changes
+    - { text: Minor changes, id: minor }
+    - { text: Major changes, id: major }
     options:
     - Not sure
     - Less than 1 per month
@@ -90,6 +96,7 @@
 
   - title: Software Upgrade - If you are automating software upgrades in your network what solution(s) are you using?
     type: Multiple choice 
+    id: software-upgrade
     responses:
     - Ansible
     - Chef
@@ -105,6 +112,7 @@
 
   - title: Software Qualification/Validation - If you are automating software qualification for your network what solution(s) are you using?
     type: Multiple choice 
+    id: software-validation
     responses:
     - Ansible
     - Chef
@@ -120,6 +128,7 @@
 
   - title: Anomaly detection – what data sources are you using to detect problems in your network ? 
     type: Multiple choice 
+    id: anomaly-detection-sources
     responses:
     - ICMP/PING
     - Other active probes (IP SLA/RPM)
@@ -133,6 +142,7 @@
 
   - title: Anomaly detection – What mechanism are you using to identify problems in your network ? 
     type: Multiple choice
+    id: anomaly-detection-signal
     responses:
     - Up/Down/Threshold alert
     - Events correlation / rule engine
@@ -145,6 +155,7 @@
   questions:
   - title: How many network devices are you managing?
     type: Single choice 
+    id: env-nbr-devices
     responses:
     - 0-50
     - 51-250
@@ -156,6 +167,7 @@
 
   - title: Which networking vendor devices are you managing?
     type: Multiple choice 
+    id: env-vendors
     responses:
     - Arista
     - Big Switch
@@ -176,6 +188,7 @@
 
   - title: What types of environments are you managing?
     type: Multiple choice 
+    id: env-type
     responses:
     - Datacenter
     - Campus/User Access
@@ -186,16 +199,17 @@
 
   - title: What programmatic language(s) are you using? 
     type: Multiple choice grid 
+    id: env-language
     responses:
-    - Python
-    - Golang
-    - Javascript
-    - Ruby
-    - C/C++
-    - Shell (Bash,...)
-    - Expect
-    - Powershell
-    - Other
+    - { text: Python, id: python }
+    - { text: Golang, id: golang }
+    - { text: Javascript, id: javascript }
+    - { text: Ruby, id: ruby }
+    - { text: C/C++, id: c-cpp }
+    - { text: Shell (Bash,...), id: shell }
+    - { text: Expect, id: expect }
+    - { text: Powershell, id: powershell }
+    - { text: Other, id: other }
     options:
     - None
     - A little
@@ -203,6 +217,7 @@
 
   - title: Which solution are you using to run virtual network devices for training or qualification purpose?
     type: Multiple choice 
+    id: env-virtual-network
     responses:
     - Vagrant
     - VMWare
@@ -222,6 +237,7 @@
 
   - title: On the server side, what automation tools are you using ?
     type: Multiple choice 
+    id: env-server-automation
     responses:
     - Ansible
     - Chef
@@ -236,6 +252,7 @@
   
   - title: Where are you located?
     type: Single choice 
+    id: env-location
     responses:
     - North America
     - South America
@@ -246,7 +263,8 @@
     - Australia, Oceania or Pacific Islands
 
   - title: What is your organization’s preferred approach for network automation tools used in production ?
-    type: Single choice 
+    type: Single choice
+    id: org-preference
     responses:
     - buy 
     - build internally
@@ -258,6 +276,7 @@
   questions:
   - title: For how long have you been leveraging automation in your network in a significant way
     type: Single choice 
+    id: transition-team-how-long
     responses:
     - Less than 1 year
     - 1 to 2 years
@@ -265,7 +284,8 @@
     - More than 5 years
 
   - title: What actions did your team take to transition to network automation
-    type: Multiple Choice 
+    type: Multiple choice
+    id: transition-team-actions
     responses:
     - Some of us learned on their own
     - Some of us took some network automation / programming training
@@ -277,7 +297,8 @@
   - title: > 
       If you (personally) have transitioned from a network engineer role to a network automation role, 
       how long did it take you to make the transition? 
-    type: Single Choice 
+    type: Single choice 
+    id: transition-self-how-long
     responses:
     - Less than 1 year
     - 1 to 2 years
@@ -287,7 +308,8 @@
   - title: > 
       If you (personally) have transitioned from a network engineer role to a network automation role, 
       How many hours did you put in training / self-learning?
-    type: Single Choice 
+    type: Single choice
+    id: transition-self-nbr-hours
     responses:
     - 0-200
     - 201-1000
@@ -297,7 +319,8 @@
   - title: > 
       If you (personally) have transitioned from a network engineer role to a network automation role, 
       How did you manage to find time for this transition?
-    type: Multiple Choice 
+    type: Multiple choice 
+    id: transition-self-find-time
     responses:
     - Learned on my own time
     - Dedicated some time per week at work
@@ -309,17 +332,18 @@
   questions:
   - title: Which of the following concepts are you interested in or have currently implemented?
     type: Multiple choice grid 
+    id: trend-topics
     responses:
-    - Infrastructure As Code
-    - Event Driven Automation
-    - Chatops
-    - Continuous Integration/ Delivery - CI/CD
-    - DevOps
-    - Streaming Telemetry
-    - Intent-based solution / IBN
-    - Source of Truth
-    - Graph Database
-    - Network Health Monitoring
+    - { text: Infrastructure As Code, id: iac }
+    - { text: Event Driven Automation, id: event-driven }
+    - { text: Chatops, id: chatops }
+    - { text: Continuous Integration/ Delivery - CI/CD, id: ci-cd }
+    - { text: DevOps, id: devops }
+    - { text: Streaming Telemetry, id: telemetry-streaming }
+    - { text: Intent-based solution / IBN, id: ibns }
+    - { text: Source of Truth, id: sot }
+    - { text: Graph Database, id: graph-db }
+    - { text: Network Health Monitoring, id: network-health } 
     options:
     - I don't know
     - No interest
@@ -329,23 +353,24 @@
 
   - title: Which of the following tools are you interested in or have currently implemented?
     type: Multiple choice grid 
+    id: trend-tools
     responses: 
-    - Ansible
-    - Chef
-    - Puppet
-    - Saltstack
-    - NAPALM
-    - Nornir
-    - Netbox
-    - ELK (Logstash/Kibana)
-    - Grafana/Prometheus/Influxdb
-    - Kentik
-    - NSO (tail-F)
-    - Git (github/gitlab)
-    - Network Verification Software (Batfish, Forward Networks, Veriflow ..)
-    - Keyword based testing (RobotFramework, Behave)
-    - CI (jenkins, travis-ci, circle-ci, gitlab-ci)
-    - Stackstorm
+    - { text: Ansible, id: ansible }
+    - { text: Chef, id: chef }
+    - { text: Puppet, id: puppet }
+    - { text: Saltstack, id: saltstack }
+    - { text: NAPALM, id: napalm }
+    - { text: Nornir, id: nornir }
+    - { text: Netbox, id: netbox }
+    - { text: ELK (Logstash/Kibana), id: elk }
+    - { text: Grafana/Prometheus/Influxdb, id: tsdb }
+    - { text: Kentik, id: kentik }
+    - { text: NSO (tail-F), id: nso }
+    - { text: Git (github/gitlab), id: git }
+    - { text: "Network Verification Software (Batfish, Forward Networks, Veriflow ..)", id: network-verification }
+    - { text: "Keyword based testing (RobotFramework, Behave)", id: keyword-testing }
+    - { text: "CI (jenkins, travis-ci, circle-ci, gitlab-ci)", id: ci }
+    - { text: Stackstorm, id: stackstorm }
     options:
     - I don't know
     - No interest
@@ -357,4 +382,5 @@
   questions:
   - title: Open form for feedback or additional information you would like to share. (Attention everyone will have access to it)
     type: Open form
+    id: feedback
 


### PR DESCRIPTION
I've started working on a solution to store the results in a database and to be able to track the responses to the same question over time I think we need to have a unique identifier per question, this way we'll be able to change the title of a question but still track responses over time.

I put together a first proposal, please let me know if that make sense to you

I tried to keep the `ids` short and human readable. beyond that there is no rule for creating these ids

For the `Multiple choice grid` questions, each option has an id but the real id should be the concatenation of the `question-id` and the `choice-id`, see below
```yaml
  - title: How often do you make changes in production
    id: prod-changes
    type: Multiple choice grid
    responses:	   
    - { text: Minor changes, id: minor }       # Real id is prod-changes-minor
    - { text: Major changes, id: major }       # Real id is prod-changes-major
```
