### PR TITLE
Cleanup Readme and add 2019 report page

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,23 +13,17 @@ You can sign up and join the Slack community here: http://slack.networktocode.co
 
 # 2019 Edition
 
-The 2019 Edition is now closed, the raw results are available here : http://bit.ly/netdevops-survey-2019-responses
+The 2019 Edition is now closed, the results are available in the results folder in TSV format or in a SQLite database 
 
-> Google also has a simple interface to explore the results : https://docs.google.com/forms/d/1lF6ZGDdiNn-HEo5WIJYiY9zU3TedNqf2thQX_mwj9Rg/viewanalytics
-
-## Agenda
-* August 1st to Oct 9th : Definition of the questionnaire (github)
-* Oct 10th to Nov 10th : Survey open for response
-* Nov 11th to Nov 25th : Cleaning results
-
-## TODO List
-* Find a solution to store raw results
-* Find a solution to create a report
+## Timing
+* August 1st to Oct 9th 2019 : Definition of the questionnaire (github)
+* Oct 10th to Nov 10th 2019: Survey open for response
+* Nov 11th 2019 to Jan 6th 2020 : Cleaning results
+* Jan 7th 2020 : Cleaned results published
 
 ## Core Team
 * Francois Caen
 * Damien Garros
-* (please reach out if you are interested to help) 
 
 ## Tools Selection and Requirements
 The netdevops survey can be broken down in 4 steps, each with it's own set of requirements
@@ -53,21 +47,20 @@ No authentification should be required.
 Survey results will be available in raw format for anyone to analyze (in 2016 the results were available in a Google Sheet).
 Ideally as we start to have multiple editions of the survey, it would be interesting to have the results available in a common format/place.
 
-**Proposed solution**: Google Spreadsheet
+**Proposed solution**: TSV file saved in Github 
 
 ### Reports
 if possible it would be great to have a solution to:
 - Collaboratively create a report with nice graphics 
 - Distribute and update this report (web UI?)
 
-**Proposed solution**: TBD, please join the discussion to help us find the best solution here
+**Proposed solution**: Markdown files in Github + Graphs generated with Pygal
 
 # 2016 Edition
 
 The first edition of the netdevops survey took place in Fall 2016
-* The raw results are available [HERE](https://drive.google.com/open?id=19zpdswVSBI4Eel_vrphB5JwUjZ7MtV0LY6Ifz57tCFE)   
-* The draft of the report is available [HERE](https://drive.google.com/open?id=1YLgCIo7DkRmHFog4teITOGmsC7KB7qQKdjkzsW2KlXs) 
- 
+* The raw results are available in the results folder in TSV format or in a SQLite database 
+
 ## Core Team
 - Jason Frazier
 - David Barroso

--- a/docs/report_2019.md
+++ b/docs/report_2019.md
@@ -1,0 +1,100 @@
+
+
+# Intro
+
+The Netdevops survey is a community driven survey that is designed to help understand how network operators and engineers are using automation to operate their network today.
+
+The 2019 Edition collected responses from 294 participants from Oct 10th to Nov 10th 2019. 
+
+If you want to get involved, please visit [our github page](https://github.com/dgarros/netdevops-survey/)
+
+# 2019 Report
+## Operation/Management of your network 
+
+![Operation Automated](../graphs/png/netdevops_survey_2019_operation-automated_tool.png)
+![](../graphs/png/netdevops_survey_operation-automated_compare.png)
+
+--------------
+
+![](../graphs/png/netdevops_survey_2019_prod-changes_stack.png)
+
+![](../graphs/png/netdevops_survey_2019_config-decide-changes_pie.png)
+
+![](../graphs/png/netdevops_survey_2019_config-automated-changes_pie.png)
+--------------
+
+![config gen deploy](../graphs/png/netdevops_survey_2019_config-gen-deploy_tool.png)
+![](../graphs/png/netdevops_survey_config-gen-deploy_compare.png)
+
+--------------
+
+![config track changes](../graphs/png/netdevops_survey_2019_config-track-changes_tool.png)
+![](../graphs/png/netdevops_survey_config-track-changes_compare.png)
+
+--------------
+
+![software upgrade](../graphs/png/netdevops_survey_2019_software-upgrade_tool.png)
+![](../graphs/png/netdevops_survey_software-upgrade_compare.png)
+
+--------------
+
+![software validation](../graphs/png/netdevops_survey_2019_software-validation_tool.png)
+![](../graphs/png/netdevops_survey_software-validation_compare.png)
+
+--------------
+
+![anomaly detection signal](../graphs/png/netdevops_survey_2019_anomaly-detection-signal_tool.png)
+![anomaly detection tools](../graphs/png/netdevops_survey_2019_anomaly-detection-sources_tool.png)
+
+--------------
+
+![virtual network](../graphs/png/netdevops_survey_2019_env-virtual-network_tool.png)
+![](../graphs/png/netdevops_survey_env-virtual-network_compare.png)
+
+## Your Environment
+
+![Nbr devices](../graphs/png/netdevops_survey_2019_env-nbr-devices_bar.png)
+
+![Location](../graphs/png/netdevops_survey_2019_env-location_pie.png)
+
+![Location](../graphs/png/netdevops_survey_2019_env-vendors_tool.png)
+
+![Env type](../graphs/png/netdevops_survey_2019_env-type_tool.png)
+
+![Env Language](../graphs/png/netdevops_survey_2019_env-language_stack.png)
+
+## Transition to Network Automation
+
+![](../graphs/png/netdevops_survey_2019_transition-self-find-time_tool.png)
+![](../graphs/png/netdevops_survey_2019_transition-self-how-long_pie.png)
+
+![](../graphs/png/netdevops_survey_2019_transition-self-nbr-hours_pie.png)
+
+![](../graphs/png/netdevops_survey_2019_transition-team-actions_tool.png)
+
+![](../graphs/png/netdevops_survey_2019_transition-team-how-long_pie.png)
+
+![](../graphs/png/netdevops_survey_2019_org-preference_bar.png)
+
+## Industry Trends / Future direction
+
+![](../graphs/png/netdevops_survey_2019_trend-tools_stack.png)
+![](../graphs/png/netdevops_survey_2019_trend-topics_stack.png)
+
+### Evolution over time
+![](../graphs/png/netdevops_survey_trend-tools_trend-tools-ansible_compare.png)
+![](../graphs/png/netdevops_survey_trend-tools_trend-tools-chef_compare.png)
+![](../graphs/png/netdevops_survey_trend-tools_trend-tools-ci_compare.png)
+![](../graphs/png/netdevops_survey_trend-tools_trend-tools-git_compare.png)
+![](../graphs/png/netdevops_survey_trend-tools_trend-tools-keyword-testing_compare.png)
+![](../graphs/png/netdevops_survey_trend-tools_trend-tools-napalm_compare.png)
+![](../graphs/png/netdevops_survey_trend-tools_trend-tools-puppet_compare.png)
+![](../graphs/png/netdevops_survey_trend-tools_trend-tools-saltstack_compare.png)
+![](../graphs/png/netdevops_survey_trend-tools_trend-tools-stackstorm_compare.png)
+![](../graphs/png/netdevops_survey_trend-topics_trend-topics-chatops_compare.png)
+![](../graphs/png/netdevops_survey_trend-topics_trend-topics-ci-cd_compare.png)
+![](../graphs/png/netdevops_survey_trend-topics_trend-topics-devops_compare.png)
+![](../graphs/png/netdevops_survey_trend-topics_trend-topics-event-driven_compare.png)
+![](../graphs/png/netdevops_survey_trend-topics_trend-topics-iac_compare.png)
+![](../graphs/png/netdevops_survey_trend-topics_trend-topics-ibns_compare.png)
+![](../graphs/png/netdevops_survey_trend-topics_trend-topics-telemetry-streaming_compare.png)

--- a/docs/report_2019.md
+++ b/docs/report_2019.md
@@ -4,9 +4,9 @@
 
 The Netdevops survey is a community driven survey that is designed to help understand how network operators and engineers are using automation to operate their network today.
 
-The 2019 Edition collected responses from 294 participants from Oct 10th to Nov 10th 2019. 
+The 2019 Edition collected responses from 293 participants from Oct 10th to Nov 10th 2019. 
 
-If you want to get involved, please visit [our github page](https://github.com/dgarros/netdevops-survey/)
+If you want to get involved or are looking for more information, please visit [our github page](https://github.com/dgarros/netdevops-survey/)
 
 # 2019 Report
 ## Operation/Management of your network 

--- a/docs/report_2019.md
+++ b/docs/report_2019.md
@@ -11,7 +11,7 @@ If you want to get involved or are looking for more information, please visit [o
 # 2019 Report
 ## Operation/Management of your network 
 
-![Operation Automated](../graphs/svg/netdevops_survey_2019_operation-automated_tool.svg)
+![Operation Automated](../graphs/png/netdevops_survey_2019_operation-automated_tool.png)
 ![](../graphs/png/netdevops_survey_operation-automated_compare.png)
 
 --------------

--- a/docs/report_2019.md
+++ b/docs/report_2019.md
@@ -11,7 +11,7 @@ If you want to get involved or are looking for more information, please visit [o
 # 2019 Report
 ## Operation/Management of your network 
 
-![Operation Automated](../graphs/png/netdevops_survey_2019_operation-automated_tool.png)
+![Operation Automated](../graphs/svg/netdevops_survey_2019_operation-automated_tool.svg)
 ![](../graphs/png/netdevops_survey_operation-automated_compare.png)
 
 --------------


### PR DESCRIPTION
I did some cleanup on the readme and I created a new page to show all the graphs related to the 2019 edition on a single page. 
I put this page under `/docs` because I would like to try to enable [Github pages](https://pages.github.com/) to see if we can get a better ui to share the results ...

The URL would be `https://dgarros.github.io/netdevops-survey/`. 
Right now it's showing the main Readme but the idea is to point it at the `docs` directory so we could have a simple/different landing page and just have couple of pages with the graphs