### PR TITLE
Cleanup options for 2020 based on 2019 responses

### DIFF
--- a/questionnaire/2020/questions.yaml
+++ b/questionnaire/2020/questions.yaml
@@ -67,8 +67,6 @@
     responses:
     - Excel macros
     - Ansible
-    - Chef
-    - Puppet
     - SaltStack
     - NSO (Tail-F)
     - Nornir
@@ -99,13 +97,13 @@
     id: software-upgrade
     responses:
     - Ansible
-    - Chef
-    - Puppet
     - SaltStack
     - Low level custom scripts (Python paramiko/socket)
     - Custom scripts using common libraries (netmiko/napalm)
     - Solarwind NCM
     - HPE Network Automation (HP NA)
+    - NSO (Tail-F)
+    - Nornir
     - Network vendor specific tools (DNAC, CVP, Space, PI ...)
     - We haven’t automated software upgrades
     - Other (text field)
@@ -115,8 +113,6 @@
     id: software-validation
     responses:
     - Ansible
-    - Chef
-    - Puppet
     - Robot Framework / Behave
     - SaltStack
     - NSO (Tail-F)
@@ -203,6 +199,7 @@
     responses:
     - { text: Python, id: python }
     - { text: Golang, id: golang }
+    - { text: Rust, id: rust }
     - { text: Javascript, id: javascript }
     - { text: Ruby, id: ruby }
     - { text: C/C++, id: c-cpp }
@@ -222,9 +219,7 @@
     - Vagrant
     - VMWare
     - OpenStack
-    - Ravello
     - vrnetlab
-    - Tesuto
     - Docker Compose
     - Kubernetes
     - Non-VMWare hypervisor (KVM, et al.)
@@ -358,8 +353,6 @@
     id: trend-tools
     responses: 
     - { text: Ansible, id: ansible }
-    - { text: Chef, id: chef }
-    - { text: Puppet, id: puppet }
     - { text: Saltstack, id: saltstack }
     - { text: NAPALM, id: napalm }
     - { text: Nornir, id: nornir }


### PR DESCRIPTION
The goal is this PR is to do some cleanup on the options available for some questions mainly based on the responses we got last year:
- Removed Chef and Puppet from most questions since they were barely mentioned in 2019 
- Added Nornir and NSO for Software upgrade since they were mentioned multiple times in 2019
- Added Rust for programming language because there's been a lot of chatter about it this year
- Removed Ravello and Tesuto for virtual environment since both are not in business anymore
 
Anything I'm missing ? 

