### PR TITLE
changed VIRL to CML/VIRL

### DIFF
--- a/questionnaire/2020/questions.yaml
+++ b/questionnaire/2020/questions.yaml
@@ -227,7 +227,7 @@
     - UNetLab
     - EVE-NG
     - Homemade solution
-    - Vendor provided solution (VIRL, Junosphere .. )
+    - Vendor provided solution (CML/VIRL, Junosphere .. )
     - We are not using virtual network devices for training or qualification
     - Other (text field)
 


### PR DESCRIPTION
Cisco recently renamed VIRL to CML. Mentioning both this year. Will remove VIRL in 2021