### PR TITLE
Add third about SOT

### DIFF
--- a/questionnaire/2020/questions.yaml
+++ b/questionnaire/2020/questions.yaml
@@ -146,6 +146,15 @@
     - Proactive monitoring data analysis using AI/ML
     - We haven’t automated the detection of anomaly
 
+  - title: Source of Truth – How are you organizing configuration data and/or inventory ? 
+    type: Multi choice
+    id: sot-how
+    - Jinja or similar templates
+    - Key-value pairs as text, JSON, YAML etc
+    - Data in a locally managed data model
+    - The devices themselves provide the source of truth (we must pull facts first before config changes)
+    - We aren't
+
 # ----------------------------------------------------
 - section: YOUR ENVIRONMENT
   questions:


### PR DESCRIPTION
Adding a third question that was proposed on Slack for discussion.

Personally I'm not sure it's adding a lot of value on top of the other 2 questions but would be good to hear some feedback

```yaml
- title: Source of Truth – How are you organizing configuration data and/or inventory ? 
    type: Multi choice
    id: sot-how
    - Jinja or similar templates
    - Key-value pairs as text, JSON, YAML etc
    - Data in a locally managed data model
    - The devices themselves provide the source of truth (we must pull facts first before config changes)
    - We aren't
```