### PR TITLE
Remove all commas and standardize list of examples

### DIFF
--- a/questionnaire/2020/questions.yaml
+++ b/questionnaire/2020/questions.yaml
@@ -15,7 +15,7 @@
     type: Multiple choice 
     id: operation-automated
     responses:
-    - Day 0 Provisioning using a vendor solution (ZTP, PnP, POAP, Amnesiac, etc.)
+    - Day 0 Provisioning using a vendor solution (ZTP/PnP/POAP/Amnesiac/etc.)
     - Configuration generation
     - Configuration deployment
     - Configuration archiving
@@ -33,7 +33,7 @@
     type: Multiple choice
     id: config-track-changes
     responses:
-    - Version control (github, gitlab, svn …)
+    - Version control (github/gitlab/svn/etc.)
     - FTP/SCP/TFTP
     - Rancid/Oxidized
     - Vendor specific tools
@@ -73,8 +73,8 @@
     - NAPALM
     - HPE Network Automation (HP NA)
     - Internally developed scripts
-    - Controller (ODL, DNAC, NSX, OpenContrail...)
-    - Network vendor specific tools (CVP, Space, PI ...)
+    - Controller (ODL/DNAC/NSX/OpenContrail/etc.)
+    - Network vendor specific tools (CVP/Space/PI/etc.)
     - Another open source project (not listed above)
     - We haven’t automated the generation or deployment of our configurations
     - Other (text field)
@@ -103,7 +103,7 @@
     - HPE Network Automation (HP NA)
     - NSO (Tail-F)
     - Nornir
-    - Network vendor specific tools (DNAC, CVP, Space, PI ...)
+    - Network vendor specific tools (DNAC/CVP/Space/PI/etc.)
     - Another open source project (not listed above)
     - We haven’t automated software upgrades
     - Other (text field)
@@ -117,7 +117,7 @@
     - SaltStack
     - NSO (Tail-F)
     - Internally developed scripts
-    - Network vendor specific tools (DNAC, CVP, Space, PI ...)
+    - Network vendor specific tools (DNAC/CVP/Space/PI/etc.)
     - Another open source project (not listed above)
     - We haven’t automated software qualification
     - Other (text field)
@@ -150,9 +150,9 @@
     type: Single choice
     id: sot-present
     responses:
-    - Yes, we have one or multiple source of data that are accurately representing the network
-    - Partially, we are trying to maintain some source of data but there is always a drift with the real network
-    - No, the configurations of our network devices is our only accurate source of information
+    - Yes - we have one or multiple source of data that are accurately representing the network
+    - Partially - we are trying to maintain some source of data but there is always a drift with the real network
+    - No - the configurations of our network devices is our only accurate source of information
 
   - title: Source of Truth – If you have a Source of Truth where are you storing your data ?
     type: Multi choice
@@ -160,9 +160,9 @@
     responses:
     - Spreadsheet
     - An Entreprise CMDB (ServiceNow)
-    - An IPAM (Infoblox, Netbox)
-    - A DCIM (Netbox, Device 42)
-    - Source Control (GitHub, GitLab, etc)
+    - An IPAM (Infoblox/Netbox/etc.)
+    - A DCIM (Netbox/Device42/etc.)
+    - Source Control (GitHub/GitLab/etc.)
     - Database implementation
     - We don’t have a source of truth
 
@@ -263,12 +263,12 @@
     - vrnetlab
     - Docker Compose
     - Kubernetes
-    - Non-VMWare hypervisor (KVM, et al.)
+    - Non-VMWare hypervisor (KVM/etc.)
     - GNS3
     - UNetLab
     - EVE-NG
     - Homemade solution
-    - Vendor provided solution (CML/VIRL, Junosphere .. )
+    - Vendor provided solution (CML/VIRL/Junosphere/etc.)
     - We are not using virtual network devices for training or qualification
     - Other (text field)
 
@@ -282,7 +282,7 @@
     - Europe
     - Middle East
     - Asia
-    - Australia, Oceania or Pacific Islands
+    - Australia / Oceania or Pacific Islands
 
   - title: What is your organization’s preferred approach for network automation tools used in production ?
     type: Single choice
@@ -292,7 +292,7 @@
     - build internally
     - use open source without support
     - use open source with support
-    - no prefered approach, varies on case by case
+    - no prefered approach / varies on case by case
 
   - title: What is your primary role within your organization?
     type: Single choice
@@ -325,10 +325,10 @@
     type: Single choice 
     id: leadership-support
     responses:
-    - Yes, this is critical to the IT leadership strategy and we have an active investment (proactive)
-    - Yes, but we are not seeing real investment (reactive)
-    - No, our leadership is not formally investing in automation, but I am to get my job done (neutral)
-    - No, the leadership is against the introduction of automation. (against)
+    - Yes - this is critical to the IT leadership strategy and we have an active investment (proactive)
+    - Yes - but we are not seeing real investment (reactive)
+    - No - our leadership is not formally investing in automation - but I am to get my job done (neutral)
+    - No - the leadership is against the introduction of automation. (against)
 
   - title: What actions did your team take to transition to network automation
     type: Multiple choice


### PR DESCRIPTION
fixes 38 by removing all commas in the responses. 
I also tried to standardize on how we are giving a list of options with `etc.` at the end instead of `...`, `etc`, `et` .. 