### PR TITLE
Update CLI/SSH  option in transport question to call out netconf

### DIFF
--- a/questionnaire/2020/questions.yaml
+++ b/questionnaire/2020/questions.yaml
@@ -244,7 +244,7 @@
     type: Multiple choice 
     id: transport-protocol
     responses:
-    - CLI/SSH
+    - CLI/SSH (Non-Netconf)
     - Netconf
     - Restconf
     - gNMI/gRPC


### PR DESCRIPTION
To be consistent with #77 for HTTP/HTTPS and RESTCONF
Proposed by @fracaen 