### PR TITLE
Added CML to trend-tools

### DIFF
--- a/questionnaire/2020/questions.yaml
+++ b/questionnaire/2020/questions.yaml
@@ -470,7 +470,9 @@
     - { text: Git (github/gitlab), id: git }
     - { text: Stackstorm, id: stackstorm }
     - { text: GNS3, id: gns3 }
-    - { text: EVE-NG, id: eve-ng }
+    - { text: EVE-NG, id: eve-ng } 
+    - { text: CML, id: cml }
+
     
     options:
     - I don't know


### PR DESCRIPTION
VIRL had little adoption last year. With the major re-write of CML, I'd like to trend adoption next to GNS3 and EVE-NG.